### PR TITLE
Update apache2-roundcube.sample.conf

### DIFF
--- a/docs/assets/apache2-roundcube.sample.conf
+++ b/docs/assets/apache2-roundcube.sample.conf
@@ -1,8 +1,9 @@
 #=====================================================================================
-# Apache2 virtual host configuration sample for Roundcube
+# Title: `Roundcube-Apache2 virtual host configuration`
 # Author: Sean Webber <https://github.com/seanthewebber>
 # Publisher: Linode, LLC <https://github.com/linode/docs>
 # Source: https://linode.com/docs/email/clients/installing-roundcube-on-ubuntu-14-04/
+# Keywords: `Roundcube,virtual host,virtualhost,SSL certificate,apache2,errorlog,customlog`
 #=====================================================================================
 
 <VirtualHost *:80>


### PR DESCRIPTION
This doc has been more SEO revised than copy edited.
Concerns: The URL is wholly different from SEO-revised Title (i.e., Roundcube-Apache2 virtual host configuration)
This title should also be the URL, unless some sytax overrides this SEO best practice (URL currently is apache2-roundcube.sample.conf)
Higher pay levels than mine should decide.
